### PR TITLE
gp/define a new route in the mock bin service

### DIFF
--- a/kong.yaml
+++ b/kong.yaml
@@ -4,3 +4,7 @@
    name: example_service
    port: 80
    protocol: http
+   routes:
+   - name: mocking
+     paths:
+     - /mock


### PR DESCRIPTION
defines a new route in the mockbin service. the route name called as mock